### PR TITLE
fix: no longer print that the port mapping is wrong when none is given

### DIFF
--- a/scioer/cli.py
+++ b/scioer/cli.py
@@ -192,10 +192,6 @@ def prompt_port(message: str, default: int) -> int:
 def port_mapping(mapping: str) -> map:
     m = re.fullmatch("^(([0-9]{1,5})(?:\/(?:tcp|udp))?):([0-9]{1,5})$", mapping)
     if not m:
-        typer.secho(
-            f"Invalid port specification '{mapping}'",
-            fg=typer.colors.RED,
-        )
         return None
 
     container = m.group(1)


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: # <!-- number of issue or pull request -->
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

[insert text here]

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
