### PR TITLE
fix: did not print the MOTD when starting a shell in the container

### DIFF
--- a/scioer/docker.py
+++ b/scioer/docker.py
@@ -165,6 +165,9 @@ def attach(client: docker.client, courseName: str, **kwargs):
         )
         return
 
+    status, out = container.exec_run("cat /scripts/motd.txt")
+    typer.echo(out)
+
     typer.echo("Starting interactive shell in the container, type `exit` to quit.")
     os.system(f"docker exec -it scioer_{courseName} bash")
 


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #48
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

[insert text here]

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
