### PR TITLE
fix: remove deprecated set-output command in workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,8 +56,8 @@ jobs:
       run: |
         current_ver="$(git describe --abbrev=0 --tags | sed 's/v//')"
         new_ver=$(semver bump "${{ github.event.inputs.version }}" "$current_ver")
-        echo "::set-output name=last::${current_ver}"
-        echo "::set-output name=new::${new_ver}"
+        echo "last=${current_ver}" >> $GITHUB_OUTPUT
+        echo "new=${new_ver}" >> $GITHUB_OUTPUT
 
     - name: "Generate release changelog"
       id: generate-changelog


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: # <!-- number of issue or pull request -->
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

[insert text here]

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
